### PR TITLE
Fix labels not resolved

### DIFF
--- a/src/model/Compiler.java
+++ b/src/model/Compiler.java
@@ -371,10 +371,11 @@ public class Compiler {
                     addresses[i] = token.addrs[i];
                     break;
                 case Instruction.FLAG_LABEL:
-                    if (labelMap.get(token.addrs[i]) == null) {
+                    Integer labelAddr = labelMap.get(token.addrs[i]);
+                    if (labelAddr == null) {
                         throw new CompileException(token.getLineNumber(), "Undefined Label!");
                     }
-                    addresses[i] = token.addrs[i];
+                    addresses[i] = labelAddr.toString();
                     break;
                 default:
                     break;

--- a/src/view/JAlphaNotationGUI.java
+++ b/src/view/JAlphaNotationGUI.java
@@ -104,7 +104,7 @@ public class JAlphaNotationGUI {
     protected JButtonCompileViewActionListener ButtonCompileActionListener;
     protected JButtonNewViewActionListener ButtonNewActionListener;
     protected JSaveViewActionListener ButtonSaveActionListener;
-    protected JButtonSaveAsViewActionListener ButtonSaveAsActionListener;
+    protected JSaveAsViewActionListener ButtonSaveAsActionListener;
     protected JLoadViewActionListener ButtonLoadActionListener;
     protected JButtonPlayViewActionListener ButtonPlayActionListener;
     protected JButtonPauseViewActionListener ButtonPauseActionListener;
@@ -323,7 +323,7 @@ public class JAlphaNotationGUI {
         this.ButtonCompileActionListener = new JButtonCompileViewActionListener(this);
         this.ButtonNewActionListener = new JButtonNewViewActionListener(this);
         this.ButtonSaveActionListener = new JSaveViewActionListener(this);
-        this.ButtonSaveAsActionListener = new JButtonSaveAsViewActionListener(this);
+        this.ButtonSaveAsActionListener = new JSaveAsViewActionListener(this);
         this.ButtonLoadActionListener = new JLoadViewActionListener(this);
         this.ButtonPlayActionListener = new JButtonPlayViewActionListener(this);
         this.ButtonPauseActionListener = new JButtonPauseViewActionListener(this);
@@ -1293,11 +1293,11 @@ public class JAlphaNotationGUI {
         ButtonSaveActionListener = buttonSaveActionListener;
     }
 
-    public JButtonSaveAsViewActionListener getButtonSaveAsActionListener() {
+    public JSaveAsViewActionListener getButtonSaveAsActionListener() {
         return ButtonSaveAsActionListener;
     }
 
-    public void setButtonSaveAsActionListener(JButtonSaveAsViewActionListener buttonSaveAsActionListener) {
+    public void setButtonSaveAsActionListener(JSaveAsViewActionListener buttonSaveAsActionListener) {
         ButtonSaveAsActionListener = buttonSaveAsActionListener;
     }
 


### PR DESCRIPTION
Wollte das Programm für SI-Arbeitsblätter ausprobieren und dabei ist mir aufgefallen, dass die Labels nicht funktionieren.
Beim überprüfen ist mir dann aufgefallen, dass Labels in addressLookup() im Compiler zwar überprüft, aber nicht geparst werden.

Nebenbei musste ich in JAlphaNotationGui den JSaveAsViewActionListener umbenennen, da das Programm sonst nicht lauffähig gewesen wäre.

